### PR TITLE
Do not retry if the device is already registered

### DIFF
--- a/src/core/peer.js
+++ b/src/core/peer.js
@@ -2082,9 +2082,11 @@ var ResourceController = function(resourceType, api, defaultDJSPeer) {
         return new Promise(function(resolve, reject) {
             function tryAgain() {
                 self._peer.registerResource(self._resourceID, resourceType).then(resolve).catch(function(error) {
-                    console.error('Error: ResourceController#start %s %s while attempting to register resource. Will retry in 5 seconds: ', self._resourceID, resourceType, error)
+                    if(!(error && error.status == 500 && error.response == "Already registered")) {
+                        console.error('Error: ResourceController#start %s %s while attempting to register resource. Will retry in 5 seconds: ', self._resourceID, resourceType, error)
 
-                    setTimeout(tryAgain, 5000)
+                        setTimeout(tryAgain, 5000)
+                    }
                 })
             }
 


### PR DESCRIPTION
@jrife This is to avoid scenario where the device is registered but devicejs keeps on trying. On gateway we see these errors every 5 seconds. 

`[1555615557:485] <WARN> {--} (--) 500 resource is already registered ZigBee1849718497
[1555615557:489] <ERROR> {stderr} (zigbee) Error: ResourceController#start ZigBee1849718497 Core/Devices/Lighting/AutogenZigbeeHA/ZigBee18497 while attempting to register resource. Will retry in 5 seconds:  { status: 500, response: 'Already registered' }
[1555615562:519] <WARN> {--} (--) 500 resource is already registered ZigBee1849718497
[1555615562:522] <ERROR> {stderr} (zigbee) Error: ResourceController#start ZigBee1849718497 Core/Devices/Lighting/AutogenZigbeeHA/ZigBee18497 while attempting to register resource. Will retry in 5 seconds:  { status: 500, response: 'Already registered' }
[1555615567:548] <WARN> {--} (--) 500 resource is already registered ZigBee1849718497
[1555615567:550] <ERROR> {stderr} (zigbee) Error: ResourceController#start ZigBee1849718497 Core/Devices/Lighting/AutogenZigbeeHA/ZigBee18497 while attempting to register resource. Will retry in 5 seconds:  { status: 500, response: 'Already registered' }
[1555615572:579] <WARN> {--} (--) 500 resource is already registered ZigBee1849718497
[1555615572:582] <ERROR> {stderr} (zigbee) Error: ResourceController#start ZigBee1849718497 Core/Devices/Lighting/AutogenZigbeeHA/ZigBee18497 while attempting to register resource. Will retry in 5 seconds:  { status: 500, response: 'Already registered' }
[1555615577:612] <WARN> {--} (--) 500 resource is already registered ZigBee1849718497
[1555615577:615] <ERROR> {stderr} (zigbee) Error: ResourceController#start ZigBee1849718497 Core/Devices/Lighting/AutogenZigbeeHA/ZigBee18497 while attempting to register resource. Will retry in 5 seconds:  { status: 500, response: 'Already registered' }
[1555615582:646] <WARN> {--} (--) 500 resource is already registered ZigBee1849718497
[1555615582:648] <ERROR> {stderr} (zigbee) Error: ResourceController#start ZigBee1849718497 Core/Devices/Lighting/AutogenZigbeeHA/ZigBee18497 while attempting to register resource. Will retry in 5 seconds:  { status: 500, response: 'Already registered' }`